### PR TITLE
[KED-3046] Remove "QuantumBlack Labs" from places where it doesn't belong any more

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
-- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
+- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
 - [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
 - [ ] Updated the documentation to reflect the code changes
 - [ ] Added tests to cover my changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kedro Training
 
-This repository contains training materials that will teach you how to use [Kedro](https://github.com/quantumblacklabs/kedro/). This content is based on the standard [spaceflights tutorial described in the Kedro documentation](https://kedro.readthedocs.io/en/stable/03_tutorial/01_spaceflights_tutorial.html). 
+This repository contains training materials that will teach you how to use [Kedro](https://github.com/kedro-org/kedro). This content is based on the standard [spaceflights tutorial described in the Kedro documentation](https://kedro.readthedocs.io/en/stable/03_tutorial/01_spaceflights_tutorial.html). 
 
 The training documentation was most recently updated against Kedro 0.17.2 in March 2021.
 
@@ -9,4 +9,4 @@ To get started, navigate to the [training_docs](./training_docs/01_welcome.md) t
 
 ## License
 
-This work, "Kedro Training", is a derivative of the ["Airflow Tutorial"](https://github.com/trallard/airflow-tutorial/) by [Tania Allard](https://github.com/trallard), used under CC BY-SA 4.0. We derived content from the [`README.md`](https://github.com/trallard/airflow-tutorial/blob/master/README.md) and ["Setup"](https://airflow-tutorial.readthedocs.io/en/stable/setup.html). "Kedro Training" is licensed under CC BY-SA 4.0 by QuantumBlack Visual Analytics Limited.
+This work, "Kedro Training", is a derivative of the ["Airflow Tutorial"](https://github.com/trallard/airflow-tutorial/) by [Tania Allard](https://github.com/trallard), used under CC BY-SA 4.0. We derived content from the [`README.md`](https://github.com/trallard/airflow-tutorial/blob/master/README.md) and ["Setup"](https://airflow-tutorial.readthedocs.io/en/stable/setup.html).

--- a/training_docs/02_prerequisites.md
+++ b/training_docs/02_prerequisites.md
@@ -30,7 +30,7 @@ There are many code editors to choose from. Here are some we recommend:
 - [Atom](https://atom.io/)
 
 ## Kedro training code
-Download the [Kedro training repository](https://github.com/quantumblacklabs/kedro-training) by following [these instructions](https://stackoverflow.com/questions/2751227/how-to-download-source-in-zip-format-from-github).
+Download the [Kedro training repository](https://github.com/kedro-org/kedro-training) by following [these instructions](https://stackoverflow.com/questions/2751227/how-to-download-source-in-zip-format-from-github).
 
 ## Git (optional)
 

--- a/training_docs/03_new_project.md
+++ b/training_docs/03_new_project.md
@@ -52,7 +52,7 @@ Follow one or other of these instructions to create the project:
 
      - Keep the default names for the `repo_name` and `python_package` when prompted.
 
-    - The project will be populated with the template code from the [Kedro starter for the spaceflights tutorial](https://github.com/quantumblacklabs/kedro-starters/tree/master/spaceflights). This means that you can follow the tutorial without any of the copy/pasting.
+    - The project will be populated with the template code from the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights). This means that you can follow the tutorial without any of the copy/pasting.
 
 * If you prefer to create an empty tutorial and copy and paste the code to follow along with the steps, you should instead run `kedro new` to [create a new empty Kedro project](https://kedro.readthedocs.io/en/stable/02_get_started/04_new_project.html#create-a-new-project-interactively).
 

--- a/training_docs/05_connect_data_sources.md
+++ b/training_docs/05_connect_data_sources.md
@@ -14,9 +14,9 @@ The spaceflights tutorial makes use of fictional datasets of companies shuttling
 
 The spaceflight tutorial has three files and uses two data formats: `.csv` and `.xlsx`. Download and save the files to the `data/01_raw/` folder of your project directory:
 
-* [reviews.csv](https://quantumblacklabs.github.io/kedro/reviews.csv)
-* [companies.csv](https://quantumblacklabs.github.io/kedro/companies.csv)
-* [shuttles.xlsx](https://quantumblacklabs.github.io/kedro/shuttles.xlsx)
+* [reviews.csv](https://kedro-org.github.io/kedro/reviews.csv)
+* [companies.csv](https://kedro-org.github.io/kedro/companies.csv)
+* [shuttles.xlsx](https://kedro-org.github.io/kedro/shuttles.xlsx)
 
 Here are some examples of how you can [download the files from GitHub](https://www.quora.com/How-do-I-download-something-from-GitHub) to the `data/01_raw` directory inside your project:
 
@@ -27,11 +27,11 @@ Using [cURL in a Unix terminal](https://curl.se/download.html):
 
 ```bash
 # reviews
-curl -o data/01_raw/reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
+curl -o data/01_raw/reviews.csv https://kedro-org.github.io/kedro/reviews.csv
 # companies
-curl -o data/01_raw/companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
+curl -o data/01_raw/companies.csv https://kedro-org.github.io/kedro/companies.csv
 # shuttles
-curl -o data/01_raw/shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
+curl -o data/01_raw/shuttles.xlsx https://kedro-org.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -41,9 +41,9 @@ Using [cURL for Windows](https://curl.se/windows/):
 <summary><b>Click to expand</b></summary>
 
 ```bat
-curl -o data\01_raw\reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
-curl -o data\01_raw\companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
-curl -o data\01_raw\shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
+curl -o data\01_raw\reviews.csv https://kedro-org.github.io/kedro/reviews.csv
+curl -o data\01_raw\companies.csv https://kedro-org.github.io/kedro/companies.csv
+curl -o data\01_raw\shuttles.xlsx https://kedro-org.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -54,11 +54,11 @@ Using [Wget in a Unix terminal](https://www.gnu.org/software/wget/):
 
 ```bash
 # reviews
-wget -O data/01_raw/reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
+wget -O data/01_raw/reviews.csv https://kedro-org.github.io/kedro/reviews.csv
 # companies
-wget -O data/01_raw/companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
+wget -O data/01_raw/companies.csv https://kedro-org.github.io/kedro/companies.csv
 # shuttles
-wget -O data/01_raw/shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
+wget -O data/01_raw/shuttles.xlsx https://kedro-org.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -68,9 +68,9 @@ Using [Wget for Windows](https://eternallybored.org/misc/wget/):
 <summary><b>Click to expand</b></summary>
 
 ```bat
-wget -O data\01_raw\reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
-wget -O data\01_raw\companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
-wget -O data\01_raw\shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
+wget -O data\01_raw\reviews.csv https://kedro-org.github.io/kedro/reviews.csv
+wget -O data\01_raw\companies.csv https://kedro-org.github.io/kedro/companies.csv
+wget -O data\01_raw\shuttles.xlsx https://kedro-org.github.io/kedro/shuttles.xlsx
 ```
 </details>
 

--- a/training_docs/06_jupyter_notebook_workflow.md
+++ b/training_docs/06_jupyter_notebook_workflow.md
@@ -249,7 +249,7 @@ To install this script simply download it into your default IPython config direc
 
 ```bash
 mkdir -p ~/.ipython/profile_default/startup
-wget -O ~/.ipython/profile_default/startup/ipython_loader.py https://raw.githubusercontent.com/quantumblacklabs/kedro/master/tools/ipython/ipython_loader.py
+wget -O ~/.ipython/profile_default/startup/ipython_loader.py https://raw.githubusercontent.com/kedro-org/kedro/master/tools/ipython/ipython_loader.py
 ```
 
 ### Prerequisites

--- a/training_docs/08_visualisation.md
+++ b/training_docs/08_visualisation.md
@@ -1,7 +1,7 @@
 
 ## Visualise your pipeline
 
-[Kedro Viz](https://github.com/quantumblacklabs/kedro-viz) shows you how your Kedro data pipelines are structured. You can use it to:
+[Kedro Viz](https://github.com/kedro-org/kedro-viz) shows you how your Kedro data pipelines are structured. You can use it to:
 
  - See how your datasets and Python functions (nodes) are resolved in Kedro so that you can understand how your data pipeline is built
  - Get a clear picture when you have lots of datasets and nodes by using tags to visualise sub-pipelines
@@ -22,7 +22,7 @@ This command will run a server on http://127.0.0.1:4141 and will open up your vi
 
 ### Examples of `kedro-viz`
 
- - You can have a look at a retail ML use case [**here**](https://quantumblacklabs.github.io/kedro-viz/)
+ - You can have a look at a retail ML use case [**here**](https://kedro-org.github.io/kedro-viz/)
  - And an example of this Spaceflights pipeline [**here**](https://medium.com/@QuantumBlack/demystifying-machine-learning-complexity-through-visualisation-11a9d73db3c5)
 
 _[Go to the next page](./09_versioning.md)_

--- a/training_docs/10_package_project.md
+++ b/training_docs/10_package_project.md
@@ -40,9 +40,9 @@ An executable, `kedro-spaceflights`, is also placed in the `bin/` subfolder of t
 
 ### Docker and Airflow
 
-We support the [Kedro-Docker](https://github.com/quantumblacklabs/kedro-docker) plugin for packaging and shipping Kedro projects within [Docker](https://www.docker.com/) containers.
+We support the [Kedro-Docker](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker) plugin for packaging and shipping Kedro projects within [Docker](https://www.docker.com/) containers.
 
-We also support [Kedro-Airflow](https://github.com/quantumblacklabs/kedro-airflow) to convert your Kedro project into an [Airflow](https://airflow.apache.org/) project.
+We also support [Kedro-Airflow](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-airflow) to convert your Kedro project into an [Airflow](https://airflow.apache.org/) project.
 
 
 ### Next section

--- a/training_docs/13_custom_datasets.md
+++ b/training_docs/13_custom_datasets.md
@@ -6,7 +6,7 @@ You can find further information about [how to add support for custom datasets](
 
 ## Contributing a custom dataset implementation
 
-One of the easiest ways to contribute back to Kedro is to share a custom dataset. Kedro has a `kedro.extras.datasets` sub-package where you can add a new custom dataset implementation to share it with others. You can find out more in the [Kedro contribution guide](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) on Github.
+One of the easiest ways to contribute back to Kedro is to share a custom dataset. Kedro has a `kedro.extras.datasets` sub-package where you can add a new custom dataset implementation to share it with others. You can find out more in the [Kedro contribution guide](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) on Github.
 
 To contribute your custom dataset:
 
@@ -24,7 +24,7 @@ kedro/extras/datasets/image
 
 3. The dataset should be accompanied by full test coverage in `tests/extras/datasets`.
 
-4. Make a pull request against the `master` branch of [Kedro's Github repository](https://github.com/quantumblacklabs/kedro).
+4. Make a pull request against the `master` branch of [Kedro's Github repository](https://github.com/kedro-org/kedro).
 
 
 _[Go to the next page](./14_custom_cli_commands.md)_

--- a/training_docs/13_custom_datasets.md
+++ b/training_docs/13_custom_datasets.md
@@ -24,7 +24,7 @@ kedro/extras/datasets/image
 
 3. The dataset should be accompanied by full test coverage in `tests/extras/datasets`.
 
-4. Make a pull request against the `master` branch of [Kedro's Github repository](https://github.com/kedro-org/kedro).
+4. Make a pull request against the `main` branch of [Kedro's Github repository](https://github.com/kedro-org/kedro).
 
 
 _[Go to the next page](./14_custom_cli_commands.md)_

--- a/training_docs/15_plugins.md
+++ b/training_docs/15_plugins.md
@@ -55,7 +55,7 @@ kedro to-json
 
 # Kedro-Docker
 
-Configuring a Docker container environment may become complex and tedious. [Kedro-Docker](https://github.com/quantumblacklabs/kedro-docker) significantly simplifies this process and reduces it to 2 steps:
+Configuring a Docker container environment may become complex and tedious. [Kedro-Docker](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker) significantly simplifies this process and reduces it to 2 steps:
 
 ## How do I install Kedro-Docker?
 
@@ -114,7 +114,7 @@ For example:
 
 # Kedro-Airflow
 
-Kedro is not a workflow scheduler. Kedro makes it easy to prototype your data pipeline, while Airflow is a complementary framework that is great at managing deployment, scheduling, monitoring and alerting. A Kedro pipeline is like a machine that builds a car part. While Airflow tells the different Kedro machines to switch on or off to work together to produce a car. We have built a [Kedro-Airflow](https://github.com/quantumblacklabs/kedro-airflow/) plugin, providing faster prototyping time and reducing the barriers to entry associated with moving pipelines to Airflow.
+Kedro is not a workflow scheduler. Kedro makes it easy to prototype your data pipeline, while Airflow is a complementary framework that is great at managing deployment, scheduling, monitoring and alerting. A Kedro pipeline is like a machine that builds a car part. While Airflow tells the different Kedro machines to switch on or off to work together to produce a car. We have built a [Kedro-Airflow](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-airflow) plugin, providing faster prototyping time and reducing the barriers to entry associated with moving pipelines to Airflow.
 
 [Apache Airflow](https://github.com/apache/airflow) is a tool for orchestrating complex workflows and data processing pipelines. The Kedro-Airflow plugin can be used for:
 - Rapid pipeline creation in the prototyping phase. You can write Python functions in Kedro without worrying about schedulers, daemons, services or having to recreate the Airflow DAG file.
@@ -146,7 +146,7 @@ The following conditions must be true for Airflow to run your pipeline:
 
 > *Note:* The generated DAG file will be placed in `$AIRFLOW_HOME/dags/` when `kedro airflow deploy` is run, where `AIRFLOW_HOME` is an environment variable. If the environment variable is not defined, Kedro-Airflow will create `~/airflow` and `~/airflow/dags` (if required) and copy the DAG file into it.
 
-If you need more customisation for Airflow, you can find more information in the [README](https://github.com/quantumblacklabs/kedro-airflow).
+If you need more customisation for Airflow, you can find more information in the [README](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-airflow).
 
 Once `dags` folder is created, you can perform airflow commands. For example, you could run `airflow initdb` to initialise the Airflow SQLite database `airflow.db` under `$AIRFLOW_HOME/dags/`, or `airflow webserver` to start Flask server for Airflow UI as follows:
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
There's a few mentions that kedro is authored by QuantumBlack Labs (e.g. in kedro docs, setup.,py, `kedro info`). Following the migration to LF these shouldn't be there any more.

Best way to find them is just to search "quantumblack" in the codebase - there's not that many results to check through.

Additionally you will also have to update URLs for Kedro-Airflow, Kedro-Docker and Kedro-Telemetry as they have completely changed repo location.

As well as kedro repository, you should check kedro-community, kedro-plugins, kedro-viz and kedro-training. kedro-starters has already been updated.

https://jira.quantumblack.com/browse/KED-3046

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added tests to cover my changes
